### PR TITLE
Bump version 1.6.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ matrix:
     env: TEST_TARGET=default
   - python: 3.6
     env: TEST_TARGET=coding_standards
+  - python: 3.7
+    env: TEST_TARGET=coding_standards
+  - python: 3.8
+    env: TEST_TARGET=coding_standards
 before_install:
 - wget http://bit.ly/miniconda -O miniconda.sh
 - bash miniconda.sh -b -p $HOME/miniconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,11 @@ matrix:
   - python: 3.6
     env: TEST_TARGET=coding_standards
   - python: 3.7
+    env: TEST_TARGET=default
+  - python: 3.7
     env: TEST_TARGET=coding_standards
+  - python: 3.8
+    env: TEST_TARGET=default
   - python: 3.8
     env: TEST_TARGET=coding_standards
 before_install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ in every released version.
 - Issues/Enhancements:
   - add custom units to the legend #128
 - Fix:
-  - Fix deprecated `_autogen_docstring` for matplotlib >3.1 (#136, #119 and #135)
+  - Fix deprecated `_autogen_docstring` for matplotlib >3.1 (#136, #117, #119, #135)
 
 ### Version 1.6.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@
 All notable changes to this code base will be documented in this file,
 in every released version.
 
-### Version 1.6.x
+### Version 1.6.8
 
-- Released: 20zz-yy-xx
+- Released: 2020-09-04
+- Issues/Enhancements:
+  - add custom units to the legend #128
 - Fix:
-    - Fix deprecated `_autogen_docstring` for matplotlib >3.1 #117
+  - Fix deprecated `_autogen_docstring` for matplotlib >3.1 (#136, #119 and #135)
 
 ### Version 1.6.7
 

--- a/Untitled.ipynb
+++ b/Untitled.ipynb
@@ -1,6 +1,0 @@
-{
- "cells": [],
- "metadata": {},
- "nbformat": 4,
- "nbformat_minor": 0
-}

--- a/windrose/version.py
+++ b/windrose/version.py
@@ -1,7 +1,7 @@
 __author__ = "Lionel Roubeyrie"
 __credits__ = ["Sebastien Celles"]
 __email__ = "s.celles@gmail.com"
-__version__ = "1.6.7"
+__version__ = "1.6.8"
 __license__ = "CeCILL-B OR BSD-3-Clause"
 __url__ = "https://github.com/python-windrose/windrose"
 __maintainer__ = "Sebastien Celles"


### PR DESCRIPTION
We need a new release to take into account the change in master that resolv: https://github.com/python-windrose/windrose/issues/136, https://github.com/python-windrose/windrose/issues/119 and https://github.com/python-windrose/windrose/issues/135 .
