### PR TITLE
Add option to specify radius steps

### DIFF
--- a/windrose/windrose.py
+++ b/windrose/windrose.py
@@ -154,7 +154,7 @@ class WindroseAxes(PolarAxes):
         rmax = self.get_rmax()
         if self.rstep is not None:
             rstep = self.rstep
-            N = np.int_(np.ceil(rmax/rstep))
+            N = np.int_(np.ceil(rmax / rstep))
             rmax = N * rstep
         else:
             N = 5
@@ -371,7 +371,7 @@ class WindroseAxes(PolarAxes):
         blowto = kwargs.pop("blowto", False)
         rstep = kwargs.pop("rstep", None)
         self.rstep = rstep
-        
+
         # Calm condition
         calm_limit = kwargs.pop("calm_limit", None)
         if calm_limit is not None:

--- a/windrose/windrose.py
+++ b/windrose/windrose.py
@@ -87,6 +87,7 @@ class WindroseAxes(PolarAxes):
         PolarAxes.__init__(self, *args, **kwargs)
         self.set_aspect("equal", adjustable="box", anchor="C")
         self.radii_angle = 67.5
+        self.rstep = None
         self.clear()
 
     @staticmethod
@@ -150,8 +151,13 @@ class WindroseAxes(PolarAxes):
         if angle is None:
             angle = self.radii_angle
         self.radii_angle = angle
-        N = 5
         rmax = self.get_rmax()
+        if self.rstep is not None:
+            rstep = self.rstep
+            N = np.int_(np.ceil(rmax/rstep))
+            rmax = N * rstep
+        else:
+            N = 5
         radii = np.linspace(0, rmax, N + 1)
         if rmax % N == 0:
             fmt = "%d"
@@ -363,7 +369,9 @@ class WindroseAxes(PolarAxes):
 
         normed = kwargs.pop("normed", False)
         blowto = kwargs.pop("blowto", False)
-
+        rstep = kwargs.pop("rstep", None)
+        self.rstep = rstep
+        
         # Calm condition
         calm_limit = kwargs.pop("calm_limit", None)
         if calm_limit is not None:


### PR DESCRIPTION
Allow user to specify the steps at which radius circles and labels will be drawn as, and also sets the rmax value to be a multiple of rstep. So for example a call to plot_windrose(t, r, kind='bar', normed=True, blowto=False, rstep=5) will generate radii/labels of 5,10,15 etc. I don't know if this the best way to achieve this (that is should this be part of WindroseAxes constructor or just passed around in kwargs?), it just worked for my use case.