### PR TITLE
Update docstring about calm_limit

### DIFF
--- a/windrose/windrose.py
+++ b/windrose/windrose.py
@@ -269,6 +269,7 @@ class WindroseAxes(PolarAxes):
         weibull_factors :
         mean_values :
         frequency :
+        calm_limit : float, default None
         kwarg
             Any argument accepted by :obj:`matplotlib.pyplot.plot`.
         """
@@ -413,6 +414,11 @@ class WindroseAxes(PolarAxes):
             colors in the order specified.
         cmap : a cm Colormap instance from :obj:`matplotlib.cm`, optional
             if cmap == None and colors == None, a default Colormap is used.
+        calm_limit : float, optional
+            Calm limit for the var parameter. If not None, a centered red
+            circle will be draw for representing the calms occurences and all
+            datas below this value will be removed from the computation.
+
         others kwargs
             Any supported argument of :obj:`matplotlib.pyplot.plot`
 
@@ -474,6 +480,10 @@ class WindroseAxes(PolarAxes):
             colors in the order specified.
         cmap : a cm Colormap instance from :obj:`matplotlib.cm`, optional
             if cmap == None and colors == None, a default Colormap is used.
+        calm_limit : float, optional
+            Calm limit for the var parameter. If not None, a centered red
+            circle will be draw for representing the calms occurences and all
+            datas below this value will be removed from the computation.
 
         others kwargs
             Any supported argument of :obj:`matplotlib.pyplot.plot`
@@ -543,6 +553,10 @@ class WindroseAxes(PolarAxes):
         opening : float, optional
             between 0.0 and 1.0, to control the space between each sector (1.0
             for no space)
+        calm_limit : float, optional
+            Calm limit for the var parameter. If not None, a centered red
+            circle will be draw for representing the calms occurences and all
+            datas below this value will be removed from the computation.
 
         """
 
@@ -617,6 +631,10 @@ class WindroseAxes(PolarAxes):
         edgecolor : string, optional
             The string color each edge bar will be plotted.  Default : no
             edgecolor
+        calm_limit : float, optional
+            Calm limit for the var parameter. If not None, a centered red
+            circle will be draw for representing the calms occurences and all
+            datas below this value will be removed from the computation.
 
         """
 


### PR DESCRIPTION
Fix #161 .

The PR #60, which involves the addition of the calm_limit option, includes a change to the docstring, but it was rejected. After that, the PR #102 seems to have been merged without any update to the docstring about calm_limit option.

This docstring was copied from #60 and was slightly formatted.