### PR TITLE
Fix default behavior of WindroseAxes.from_ax().

### DIFF
--- a/windrose/windrose.py
+++ b/windrose/windrose.py
@@ -78,7 +78,9 @@ class WindroseAxes(PolarAxes):
         # when the instance is created
         # self.RESOLUTION = kwargs.pop('resolution', 100)
         self.rmax = kwargs.pop("rmax", None)
-        self.theta_labels = kwargs.pop("theta_labels", ["E", "N-E", "N", "N-W", "W", "S-W", "S", "S-E"])
+        self.theta_labels = kwargs.pop("theta_labels", None)
+        if self.theta_labels is None:
+            self.theta_labels = ["E", "N-E", "N", "N-W", "W", "S-W", "S", "S-E"]
         PolarAxes.__init__(self, *args, **kwargs)
         self.set_aspect("equal", adjustable="box", anchor="C")
         self.radii_angle = 67.5


### PR DESCRIPTION
Fix #165.

First, returns None if it does not have a key or if None is set.
Then, if None, then assign ["E", ...].

```python
self.theta_labels = kwargs.pop("theta_labels", None)
if self.theta_labels is None:
    self.theta_labels = ["E", "N-E", "N", "N-W", "W", "S-W", "S", "S-E"])
```
