### PR TITLE
fix np.float deprecation warning

### DIFF
--- a/windrose/windrose.py
+++ b/windrose/windrose.py
@@ -752,7 +752,7 @@ def histogram(direction, var, bins, nsector, normed=False, blowto=False):
 
     angle = 360. / nsector
 
-    dir_bins = np.arange(-angle / 2, 360. + angle, angle, dtype=np.float)
+    dir_bins = np.arange(-angle / 2, 360. + angle, angle, dtype=float)
     dir_edges = dir_bins.tolist()
     dir_edges.pop(-1)
     dir_edges[0] = dir_edges.pop(-1)


### PR DESCRIPTION
I encountered a deprecation warning from numpy:
```
DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    dir_bins = np.arange(-angle / 2, 360. + angle, angle, dtype=np.float)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
```
simply replacing `numpy.float` with the built in `float` should fix this.