### PR TITLE
Build and upload docs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,47 @@
+name: Build and Deploy docs
+
+on:
+  push:
+    branches:
+      - [master, main]
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Setup Mamba
+      uses: mamba-org/provision-with-micromamba@main
+      with:
+        environment-file: false
+
+    - name: Build environment
+      shell: bash -l {0}
+      run: |
+        micromamba create --name TEST python=3 --file requirements.txt --file requirements-dev.txt --channel conda-forge
+        micromamba activate TEST
+        python -m pip install -e . --no-deps --force-reinstall
+
+    - name: Get the version
+      id: get_version
+      run: echo ::set-output name=VERSION::$(python setup.py --version)
+
+    - name: Build documentation
+      shell: bash -l {0}
+      run: |
+        set -e
+        micromamba activate TEST
+        pushd docs
+        make clean html linkcheck
+        popd
+
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v3.6.1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: docs/_build/html

--- a/README.md
+++ b/README.md
@@ -4,12 +4,9 @@
 [![Wheel format](https://img.shields.io/pypi/wheel/windrose.svg)](https://pypi.python.org/pypi/windrose/)
 [![License](https://img.shields.io/pypi/l/windrose.svg)](https://pypi.python.org/pypi/windrose/)
 [![Development Status](https://img.shields.io/pypi/status/windrose.svg)](https://pypi.python.org/pypi/windrose/)
-[![Requirements Status](https://requires.io/github/python-windrose/windrose/requirements.svg?branch=master)](https://requires.io/github/python-windrose/windrose/requirements/?branch=master)
-[![Code Health](https://landscape.io/github/python-windrose/windrose/master/landscape.svg?style=flat)](https://landscape.io/github/python-windrose/windrose/master)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/0c8af4ef10064de09a49bbe933479228)](https://www.codacy.com/project/s-celles/windrose_2/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=python-windrose/windrose&amp;utm_campaign=Badge_Grade_Dashboard)
-[![Build Status](https://travis-ci.org/python-windrose/windrose.svg?branch=master)](https://travis-ci.org/python-windrose/windrose)
+[![Tests](https://github.com/python-windrose/windrose/actions/workflows/tests.yml/badge.svg)](https://github.com/python-windrose/windrose/actions/workflows/tests.yml)
 [![DOI](https://zenodo.org/badge/37549137.svg)](https://zenodo.org/badge/latestdoi/37549137)
-[![DOI](http://joss.theoj.org/papers/10.21105/joss.00268/status.svg)](https://doi.org/10.21105/joss.00268)
+[![JOSS](https://joss.theoj.org/papers/10.21105/joss.00268/status.svg)](https://joss.theoj.org/papers/10.21105/joss.00268)
 
 # Windrose
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,7 +95,7 @@ html_theme = "sphinx_rtd_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+# html_static_path = ["_static"]
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,5 @@
 |Latest Version| |Supported Python versions| |Wheel format| |License|
-|Development Status| |Downloads monthly| |Build Status| |DOI| |Research software impact|
+|Development Status| |Downloads monthly| |Tests| |DOI| |Research software impact|
 
 .. windrose documentation master file, created by
    sphinx-quickstart on Tue May  1 16:51:19 2018.
@@ -44,8 +44,8 @@ https://docs.github.com/en/pull-requests/collaborating-with-pull-requests
    :target: https://pypi.org/project/windrose/
 .. |Downloads monthly| image:: https://img.shields.io/pypi/dm/windrose.svg
    :target: https://pypi.org/project/windrose/
-.. |Build Status| image:: https://api.travis-ci.org/python-windrose/windrose.svg
-   :target: https://travis-ci.org/python-windrose/windrose
+.. |Tests| image:: https://github.com/python-windrose/windrose/actions/workflows/tests.yml/badge.svg
+   :target: https://github.com/python-windrose/windrose/actions/workflows/tests.yml
 .. |DOI| image:: https://zenodo.org/badge/37549137.svg
    :target: https://zenodo.org/badge/latestdoi/37549137
 .. |Research software impact| image:: http://depsy.org/api/package/pypi/windrose/badge.svg

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,12 +50,6 @@ https://docs.github.com/en/pull-requests/collaborating-with-pull-requests
    :target: https://zenodo.org/badge/latestdoi/37549137
 .. |Research software impact| image:: http://depsy.org/api/package/pypi/windrose/badge.svg
    :target: http://depsy.org/package/python/windrose
-.. |Video1| image:: http://img.youtube.com/vi/0u2RxtGgEFo/0.jpg
-   :target: https://www.youtube.com/watch?v=0u2RxtGgEFo
-.. |Video2| image:: http://img.youtube.com/vi/3CWpjSEt0so/0.jpg
-   :target: https://www.youtube.com/watch?v=3CWpjSEt0so
-.. |Video3| image:: http://img.youtube.com/vi/UiGC-3aw9TM/0.jpg
-   :target: https://www.youtube.com/watch?v=UiGC-3aw9TM
 
 Indices and tables
 ==================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,5 @@
 |Latest Version| |Supported Python versions| |Wheel format| |License|
-|Development Status| |Downloads monthly| |Requirements Status| |Code
-Health| |Codacy Badge| |Build Status| |DOI| |Research software impact|
+|Development Status| |Downloads monthly| |Build Status| |DOI| |Research software impact|
 
 .. windrose documentation master file, created by
    sphinx-quickstart on Tue May  1 16:51:19 2018.
@@ -27,31 +26,25 @@ computation.
 
 Original code forked from: - windrose 1.4 by `Lionel
 Roubeyrie <https://github.com/LionelR>`__ lionel.roubeyrie@gmail.com
-http://youarealegend.blogspot.fr/search/label/windrose
+http://youarealegend.blogspot.com/search/label/windrose
 
 
 
-https://help.github.com/categories/collaborating/
+https://docs.github.com/en/pull-requests/collaborating-with-pull-requests
 
 .. |Latest Version| image:: https://img.shields.io/pypi/v/windrose.svg
-   :target: https://pypi.python.org/pypi/windrose/
+   :target: https://pypi.org/project/windrose/
 .. |Supported Python versions| image:: https://img.shields.io/pypi/pyversions/windrose.svg
-   :target: https://pypi.python.org/pypi/windrose/
+   :target: https://pypi.org/project/windrose/
 .. |Wheel format| image:: https://img.shields.io/pypi/wheel/windrose.svg
-   :target: https://pypi.python.org/pypi/windrose/
+   :target: https://pypi.org/project/windrose/
 .. |License| image:: https://img.shields.io/pypi/l/windrose.svg
-   :target: https://pypi.python.org/pypi/windrose/
+   :target: https://pypi.org/project/windrose/
 .. |Development Status| image:: https://img.shields.io/pypi/status/windrose.svg
-   :target: https://pypi.python.org/pypi/windrose/
+   :target: https://pypi.org/project/windrose/
 .. |Downloads monthly| image:: https://img.shields.io/pypi/dm/windrose.svg
-   :target: https://pypi.python.org/pypi/windrose/
-.. |Requirements Status| image:: https://requires.io/github/python-windrose/windrose/requirements.svg?branch=master
-   :target: https://requires.io/github/python-windrose/windrose/requirements/?branch=master
-.. |Code Health| image:: https://landscape.io/github/python-windrose/windrose/master/landscape.svg?style=flat
-   :target: https://landscape.io/github/python-windrose/windrose/master
-.. |Codacy Badge| image:: https://www.codacy.com/project/badge/fff3df3be0754829925202cdd6495ce7
-   :target: https://www.codacy.com/app/s-celles/windrose_2
-.. |Build Status| image:: https://travis-ci.org/python-windrose/windrose.svg
+   :target: https://pypi.org/project/windrose/
+.. |Build Status| image:: https://api.travis-ci.org/python-windrose/windrose.svg
    :target: https://travis-ci.org/python-windrose/windrose
 .. |DOI| image:: https://zenodo.org/badge/37549137.svg
    :target: https://zenodo.org/badge/latestdoi/37549137

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -4,16 +4,16 @@ Install
 Requirements
 ~~~~~~~~~~~~
 
--  matplotlib http://matplotlib.org/
--  numpy http://www.numpy.org/
+-  matplotlib https://matplotlib.org/
+-  numpy https://numpy.org/
 -  and naturally python https://www.python.org/ :-P
 
 Option libraries:
 
--  Pandas http://pandas.pydata.org/ (to feed plot functions easily)
--  Scipy http://www.scipy.org/ (to fit data with Weibull distribution)
+-  Pandas https://pandas.pydata.org/ (to feed plot functions easily)
+-  SciPy https://scipy.org/ (to fit data with Weibull distribution)
 -  ffmpeg https://www.ffmpeg.org/ (to output video)
--  click http://click.pocoo.org/ (for command line interface tools)
+-  click https://click.palletsprojects.com/ (for command line interface tools)
 
 Install latest release version via pip
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -312,6 +312,13 @@ Video export
 A video of plots can be exported. A playlist of videos is available at
 https://www.youtube.com/playlist?list=PLE9hIvV5BUzsQ4EPBDnJucgmmZ85D_b-W
 
+See:
+
+|Video1|
+
+|Video2|
+
+|Video3|
 
 `Source code <https://github.com/python-windrose/windrose/blob/master/samples/example_animate.py>`__
 
@@ -324,3 +331,10 @@ Use:
     $ python samples/example_animate.py --help
 
 to display command line interface usage.
+
+.. |Video1| image:: http://img.youtube.com/vi/0u2RxtGgEFo/0.jpg
+   :target: https://www.youtube.com/watch?v=0u2RxtGgEFo
+.. |Video2| image:: http://img.youtube.com/vi/3CWpjSEt0so/0.jpg
+   :target: https://www.youtube.com/watch?v=3CWpjSEt0so
+.. |Video3| image:: http://img.youtube.com/vi/UiGC-3aw9TM/0.jpg
+   :target: https://www.youtube.com/watch?v=UiGC-3aw9TM

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -4,7 +4,7 @@ Notebook example
 An `IPython (Jupyter) <http://ipython.org/>`__ notebook showing this
 package usage is available at:
 
--  http://nbviewer.ipython.org/github/python-windrose/windrose/blob/master/windrose_sample_random.ipynb
+-  https://nbviewer.org/github/python-windrose/windrose/blob/master/windrose_sample_random.ipynb
 
 Script example
 --------------
@@ -267,7 +267,7 @@ Functional API
 Instead of using object oriented approach like previously shown, some
 "shortcut" functions have been defined: ``wrbox``, ``wrbar``,
 ``wrcontour``, ``wrcontourf``, ``wrpdf``. See `unit
-tests <tests/test_windrose.py>`__.
+tests <https://github.com/python-windrose/windrose/blob/master/tests/test_windrose.py>`__.
 
 Pandas support
 --------------
@@ -310,13 +310,10 @@ Video export
 ------------
 
 A video of plots can be exported. A playlist of videos is available at
-https://www.youtube.com/playlist?list=PLE9hIvV5BUzsQ4EPBDnJucgmmZ85D\_b-W
+https://www.youtube.com/playlist?list=PLE9hIvV5BUzsQ4EPBDnJucgmmZ85D_b-W
 
-See:
 
-|Video1| |Video2| |Video3|
-
-`Source code <samples/example_animate.py>`__
+`Source code <https://github.com/python-windrose/windrose/blob/master/samples/example_animate.py>`__
 
 This is just a sample for now. API for video need to be created.
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,5 @@
 flake8
 pytest
 coverage
+sphinx
+sphinx_rtd_theme


### PR DESCRIPTION
In this PR:

- add a GHA that builds and uploads the docs to gh-pages (b/c there are docs on readthedocs we may not want the latter);
- fix all broken links, broken references, permanent redirection, added linkcheck to avoid regressions;
- removed broken badges and replaced the Travis-CI badge with the GitHub Actions one.