### PR TITLE
We no longer support Python 2k, so no universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,9 +50,6 @@ advanced =
 [sdist]
 formats = gztar
 
-[bdist_wheel]
-universal = 1
-
 [check-manifest]
 ignore =
     *.yaml


### PR DESCRIPTION
Forgot this in #178. The code is py>=3.6 for a while now and we cannot build a universal wheel that would be installable in py2k.