### PR TITLE
fix gh-pages publication

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,8 +1,11 @@
 name: Build and Deploy docs
 
 on:
+  pull_request:
+
   push:
-    branches: [master, main]
+    tags:
+      - "v*"
 
 jobs:
   build-docs:
@@ -42,6 +45,7 @@ jobs:
         popd
 
     - name: Deploy
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
       uses: peaceiris/actions-gh-pages@v3.8.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
For some reason the gh-pages were not activated and we were also publishing docs in every merge. This will fix the latter by publishing only when there is a new tag and I fixed the former in the settings.