### PR TITLE
skip codespell on therefor

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
               .*\.ipynb
           )$
       args:
-        - --ignore-words-list=celles,hist
+        - --ignore-words-list=celles,hist,therefor
 
 - repo: https://github.com/keewis/blackdoc
   rev: v0.3.8


### PR DESCRIPTION
Skipping this word b/c we should not edit the license file.