### PR TITLE
fix compatibility issue with numpy 1.24

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 matplotlib >=3
-numpy
+numpy >=1.21
 pandas
 scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ zip_safe = True
 include_package_data = True
 install_requires =
     matplotlib >=3
-    numpy >=1.19
+    numpy >=1.21
 python_requires = >=3.6
 packages = find:
 

--- a/windrose/windrose.py
+++ b/windrose/windrose.py
@@ -799,7 +799,7 @@ def histogram(direction, var, bins, nsector, normed=False, blowto=False):
         direction = direction + 180.0
         direction[direction >= 360.0] = direction[direction >= 360.0] - 360
 
-    table = histogram2d(x=var, y=direction, bins=[var_bins, dir_bins], normed=False)[0]
+    table = histogram2d(x=var, y=direction, bins=[var_bins, dir_bins], density=False)[0]
     # add the last value to the first to have the table of North winds
     table[:, 0] = table[:, 0] + table[:, -1]
     # and remove the last col


### PR DESCRIPTION
the package is currently broken with numpy>1.23 since `histogram2d` removed the `normed` argument (release notes: https://numpy.org/doc/stable/release/1.24.0-notes.html#expired-deprecations, pull request: https://github.com/numpy/numpy/pull/21645)

the docs and release notes just suggest using `density` as a drop in replacement instead (that's what the PR does)

for `numpy.histogram` it is already correct: https://github.com/python-windrose/windrose/blob/d05f76eb51478aab12a0a026961dffe5db9a32c4/windrose/windrose.py#L748

EDIT: we should probably also make a release after this to fix installations from PyPi (usually people shouldn't have `numpy` pinned)
