### PR TITLE
Exclude calm data from computation as promised

### DIFF
--- a/windrose/windrose.py
+++ b/windrose/windrose.py
@@ -427,9 +427,9 @@ class WindroseAxes(PolarAxes):
 
         Other Parameters
         ----------------
-        sector : integer, optional
+        nsector : integer, optional
             number of sectors used to compute the windrose table. If not set,
-            nsectors=16, then each sector will be 360/16=22.5°, and the
+            nsector=16, then each sector will be 360/16=22.5°, and the
             resulting computed table will be aligned with the cardinals points.
         bins : 1D array or integer, optional
             number of bins, or a sequence of bins variable. If not set, bins=6,
@@ -495,7 +495,7 @@ class WindroseAxes(PolarAxes):
         ----------------
         nsector: integer, optional
             number of sectors used to compute the windrose table. If not set,
-            nsectors=16, then each sector will be 360/16=22.5°, and the
+            nsector=16, then each sector will be 360/16=22.5°, and the
             resulting computed table will be aligned with the cardinals points.
         bins : 1D array or integer, optional
             number of bins, or a sequence of bins variable. If not set, bins=6,
@@ -567,7 +567,7 @@ class WindroseAxes(PolarAxes):
         ----------------
         nsector : integer, optional
             number of sectors used to compute the windrose table. If not set,
-            nsectors=16, then each sector will be 360/16=22.5°, and the
+            nsector=16, then each sector will be 360/16=22.5°, and the
             resulting computed table will be aligned with the cardinals points.
         bins : 1D array or integer, optional
             number of bins, or a sequence of bins variable. If not set, bins=6
@@ -648,7 +648,7 @@ class WindroseAxes(PolarAxes):
         ----------------
         nsector: integer, optional
             number of sectors used to compute the windrose table. If not set,
-            nsectors=16, then each sector will be 360/16=22.5°, and the
+            nsector=16, then each sector will be 360/16=22.5°, and the
             resulting computed table will be aligned with the cardinals points.
         bins : 1D array or integer, optional
             number of bins, or a sequence of bins variable. If not set, bins=6

--- a/windrose/windrose.py
+++ b/windrose/windrose.py
@@ -304,6 +304,19 @@ class WindroseAxes(PolarAxes):
             Any argument accepted by :obj:`matplotlib.pyplot.plot`.
         """
 
+        normed = kwargs.pop("normed", False)
+        blowto = kwargs.pop("blowto", False)
+
+        # Calm condition, mask data if needed
+        calm_limit = kwargs.pop("calm_limit", None)
+        if calm_limit is not None:
+            mask = var > calm_limit
+            self.calm_count = len(var) - np.count_nonzero(mask)
+            if normed:
+                self.calm_count = self.calm_count * 100 / len(var)
+            var = var[mask]
+            direction = direction[mask]
+
         # if weibull factors are entered overwrite direction and var
         if "weibull_factors" in kwargs or "mean_values" in kwargs:
             if "weibull_factors" in kwargs and "mean_values" in kwargs:
@@ -374,19 +387,6 @@ class WindroseAxes(PolarAxes):
 
         # Building the angles list
         angles = np.arange(0, -2 * np.pi, -2 * np.pi / nsector) + np.pi / 2
-
-        normed = kwargs.pop("normed", False)
-        blowto = kwargs.pop("blowto", False)
-
-        # Calm condition
-        calm_limit = kwargs.pop("calm_limit", None)
-        if calm_limit is not None:
-            mask = var > calm_limit
-            self.calm_count = len(var) - np.count_nonzero(mask)
-            if normed:
-                self.calm_count = self.calm_count * 100 / len(var)
-            var = var[mask]
-            direction = direction[mask]
 
         # Set the global information dictionary
         self._info["dir"], self._info["bins"], self._info["table"] = histogram(


### PR DESCRIPTION
This was promised in plotting methods:
"...all data below this value will be removed from the computation."

Previously, the legend would start with '[0.0' in the first label, even with calm_limit > 0. Now labels are accurate.