### PR TITLE
fix an invalid escape in the subplots example by using a raw string

### DIFF
--- a/notebooks/usage.ipynb
+++ b/notebooks/usage.ipynb
@@ -431,7 +431,7 @@
     "y_ticks = range(0, 17, 4)\n",
     "for ax in g.axes:\n",
     "    ax.set_legend(\n",
-    "        title=\"$m \\cdot s^{-1}$\", bbox_to_anchor=(1.15, -0.1), loc=\"lower right\"\n",
+    "        title=r\"$m \\cdot s^{-1}$\", bbox_to_anchor=(1.15, -0.1), loc=\"lower right\"\n",
     "    )\n",
     "    ax.set_rgrids(y_ticks, y_ticks)\n",
     "\n",


### PR DESCRIPTION
I made a small mistake in #242 - flake8 complains about `\c` being an invalid escape sequence.

Using a raw string should fix it.